### PR TITLE
chore: update name and url in header

### DIFF
--- a/lib/monologue.js
+++ b/lib/monologue.js
@@ -1,8 +1,8 @@
 /**
- * monologue.js - EventEmitter replacement with AMQP-style bindings and other advanced features. Compatible with postal.js's API.
+ * node-monologue - EventEmitter replacement with AMQP-style bindings and other advanced features. Compatible with postal.js's API.
  * Author: Foo-Foo-MQ
  * Version: v0.3.5
- * Url: https://github.com/Foo-Foo-MQ/monologue.js
+ * Url: https://github.com/Foo-Foo-MQ/node-monologue
  * License(s): MIT, GPL
  */
 const _ = require('lodash');


### PR DESCRIPTION
The project moved from `https://github.com/Foo-Foo-MQ/monologue.js` to `https://github.com/Foo-Foo-MQ/node-monologue` at some point, and seems it was renamed to `node-monologue`.

This PR simply updates the information in the header of `lib/monologue.js` so both pieces of information are current.